### PR TITLE
Added /mod roles, and removed all old methods of adding mature/image roles.

### DIFF
--- a/configs/core.ts
+++ b/configs/core.ts
@@ -1,7 +1,9 @@
 import type core from './coreType';
 
 const config: core = {
-  Global_Commands: true  // Set this to false in development
+  Global_Commands: true, // Set this to false in development
+  Discord_Bot_Token: '',
+  MongoDB_URI: ''
 };
 
 export default config;

--- a/configs/customisations.ts
+++ b/configs/customisations.ts
@@ -9,17 +9,11 @@ const config: customisations = {
     timeout: 30,
     kick: 30,
     ban: 30,
-    add_mature: 30,
-    remove_mature: 30,
-    disable_images: 30,
-    enable_images: 30,
     default: 30
   },
   Staff_Cant_Punish_Staff_Restriction: {
     verify: false,
-    add_mature: false,
     add_note: false,
-    enable_images: false
   }
 };
 

--- a/configs/customisationsType.d.ts
+++ b/configs/customisationsType.d.ts
@@ -7,10 +7,6 @@ export default interface customisations {
     timeout: number,
     kick: number,
     ban: number,
-    add_mature: number,
-    remove_mature: number,
-    disable_images: number,
-    enable_images: number,
     default: number
   },
   Staff_Cant_Punish_Staff_Restriction: {
@@ -20,9 +16,5 @@ export default interface customisations {
     timeout?: boolean,
     kick?: boolean,
     ban?: boolean,
-    add_mature?: boolean,
-    remove_mature?: boolean,
-    disable_images?: boolean,
-    enable_images?: boolean,
   },
 }

--- a/configs/snowflakeMap.ts
+++ b/configs/snowflakeMap.ts
@@ -1,6 +1,18 @@
 import type snowflakeMap from './snowflakeMapType';
 
 const config: snowflakeMap = {
+  Staff_Roles: [],
+  Sr_Staff_Roles: [],
+  Report_Notification_Roles: [],
+  Report_Banned_Roles: [],
+  Reports_Channels: [],
+  Sr_Notify_Channel: '',
+  Mod_Logs_Channels: {},
+  Verified_Roles: [],
+  Mature_Roles: [],
+  Image_Ban_Roles: [],
+  Support_Channel: '',
+  Mod_Editable_Roles: {}
 }
 
 export default config;

--- a/configs/snowflakeMap.ts
+++ b/configs/snowflakeMap.ts
@@ -9,7 +9,6 @@ const config: snowflakeMap = {
   Sr_Notify_Channel: '',
   Mod_Logs_Channels: {},
   Verified_Roles: [],
-  Mature_Roles: [],
   Image_Ban_Roles: [],
   Support_Channel: '',
   Mod_Editable_Roles: {}

--- a/configs/snowflakeMapType.d.ts
+++ b/configs/snowflakeMapType.d.ts
@@ -52,11 +52,6 @@ export default interface snowflakeMap {
   Verified_Roles: string[];
 
   /**
-   * A list of roles that members can receive and be removed with /mod user Add Mature / Remove Mature
-   */
-  Mature_Roles: string[];
-
-  /**
    * A list of roles that deny members from sending images
    */
   Image_Ban_Roles: string[];
@@ -65,4 +60,9 @@ export default interface snowflakeMap {
    * A channel used in user-facing error messages to get support at
    */
   Support_Channel: string;
+
+  /**
+   * A list of roles we allow mods to add / remove on users.
+   */
+  Mod_Editable_Roles: Record<string, string>;
 }

--- a/src/commands/cmd.mod.ts
+++ b/src/commands/cmd.mod.ts
@@ -7,4 +7,5 @@ export default new ResponsiveSlashCommandBuilder()
   .setDefaultMemberPermissions('0')
   .addSubcommand((await import(t`./subcommands/mod/cmd.mod.user.js`)).default)
   .addSubcommand((await import(t`./subcommands/mod/cmd.mod.message.js`)).default)
-  .addSubcommand((await import(t`./subcommands/mod/cmd.mod.logs.js`)).default);
+  .addSubcommand((await import(t`./subcommands/mod/cmd.mod.logs.js`)).default)
+  .addSubcommand((await import(t`./subcommands/mod/cmd.mod.roles.js`)).default);

--- a/src/commands/subcommands/mod/cmd.mod.roles.ts
+++ b/src/commands/subcommands/mod/cmd.mod.roles.ts
@@ -1,0 +1,63 @@
+import { SlashCommandUserOption } from '@discordjs/builders';
+import { ResponsiveSlashCommandSubcommandBuilder } from '@interactionHandling/commandBuilders.js';
+import { GuildMemberRoleManager } from 'discord.js';
+import { getSnowflakeMap } from '@utils.js';
+import DROPDOWNS from '@resources/dropdowns.js';
+import type { RoleInfo } from '@resources/dropdowns/dropdowns.roles.js';
+
+export default new ResponsiveSlashCommandSubcommandBuilder()
+  .setName('roles')
+  .setDescription('Edit roles for a user')
+  .addUserOption(new SlashCommandUserOption()
+    .setName('user')
+    .setDescription('The user to edit roles for')
+    .setRequired(true)
+  )
+  .setResponse(async (interaction, _interactionHandler, _command) => {
+    if (!interaction.isCommand()) return;
+    await interaction.deferReply({ ephemeral: true });
+
+    const SNOWFLAKE_MAP = await getSnowflakeMap();
+
+    const IS_STAFF_MEMBER =
+      interaction.member?.roles instanceof GuildMemberRoleManager ?
+        interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Staff_Roles) :
+
+        interaction.member?.roles instanceof Array ?
+          SNOWFLAKE_MAP.Staff_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          undefined;
+
+    if (!IS_STAFF_MEMBER) {
+      await interaction.followUp({ content: 'You do not have permission to use this command.', ephemeral: true });
+      return;
+    }
+
+    const user = interaction.options.getUser('user', true);
+    const member = interaction.guild?.members.cache.get(user.id);
+
+    if (!member || !(member.roles instanceof GuildMemberRoleManager)) return
+
+    if(!member.manageable) {
+      await interaction.followUp('Unable to edit roles for this user.');
+      return;
+    }
+
+    const USER_ROLES = member.roles.cache.map((role: { id: string; }) => role.id);
+
+    const DROPDOWN_ROLES: RoleInfo[] = Object.entries(SNOWFLAKE_MAP.Mod_Editable_Roles).map(([label, role]) => {
+      return {
+        label,
+        role,
+        enabled: USER_ROLES.includes(role)
+      }
+    })
+
+    await (await DROPDOWNS.modEditRoleRow(DROPDOWN_ROLES, member)).components.forEach(i => _interactionHandler.addComponent(i));
+
+    await interaction.followUp({
+      components: [
+        await DROPDOWNS.modEditRoleRow(DROPDOWN_ROLES, member)
+      ],
+      ephemeral: true
+    });
+  });

--- a/src/resources/commandTemplates/templates.ActionCommand.ts
+++ b/src/resources/commandTemplates/templates.ActionCommand.ts
@@ -284,30 +284,6 @@ export default class ActionCommand extends ResponsiveSlashCommandSubcommandBuild
       (member: GuildMember, reason: string, days?: number) => Promise<boolean>,
       ExtraActionOptions
     ],
-    [
-      APIApplicationCommandOptionChoice<string>,
-      (member: GuildMember) => Promise<boolean>,
-      (member: GuildMember, reason: string) => Promise<boolean>,
-      ExtraActionOptions
-    ],
-    [
-      APIApplicationCommandOptionChoice<string>,
-      (member: GuildMember) => Promise<boolean>,
-      (member: GuildMember, reason: string) => Promise<boolean>,
-      ExtraActionOptions
-    ],
-    [
-      APIApplicationCommandOptionChoice<string>,
-      (member: GuildMember) => Promise<boolean>,
-      (member: GuildMember, reason: string) => Promise<boolean>,
-      ExtraActionOptions
-    ],
-    [
-      APIApplicationCommandOptionChoice<string>,
-      (member: GuildMember) => Promise<boolean>,
-      (member: GuildMember, reason: string) => Promise<boolean>,
-      ExtraActionOptions
-    ],
   ] = [
       [
         {
@@ -397,66 +373,6 @@ export default class ActionCommand extends ResponsiveSlashCommandSubcommandBuild
           return !!(await member.ban({ reason, deleteMessageSeconds: DURATION ? Math.trunc(DURATION / 1000) : 0 }));
         },
         { sendNoticeFirst: true, emoji: ':hammer:', pastTense: 'Banned', color: 0xe63624 },
-      ],
-      [
-        {
-          name: 'Add Mature',
-          value: 'add_mature',
-        },
-        async (member) => {
-          return member.manageable;
-        },
-        async (member, reason) => {
-          if (!member.manageable) return false;
-          const SNOWFLAKE_MAP = await getSnowflakeMap();
-          return !!(await member.roles.add(SNOWFLAKE_MAP.Mature_Roles, reason));
-        },
-        { emoji: ':white_check_mark:', pastTense: 'Gave the mature role to', color: Colors.Green },
-      ],
-      [
-        {
-          name: 'Remove Mature',
-          value: 'remove_mature',
-        },
-        async (member) => {
-          return member.manageable;
-        },
-        async (member, reason) => {
-          if (!member.manageable) return false;
-          const SNOWFLAKE_MAP = await getSnowflakeMap();
-          return !!(await member.roles.remove(SNOWFLAKE_MAP.Mature_Roles, reason));
-        },
-        { emoji: ':white_check_mark:', pastTense: 'Removed the mature role from', color: Colors.Yellow },
-      ],
-      [
-        {
-          name: 'Disable image sending',
-          value: 'disable_images',
-        },
-        async (member) => {
-          return member.manageable;
-        },
-        async (member, reason) => {
-          if (!member.manageable) return false;
-          const SNOWFLAKE_MAP = await getSnowflakeMap();
-          return !!(await member.roles.add(SNOWFLAKE_MAP.Image_Ban_Roles, reason));
-        },
-        { emoji: ':white_check_mark:', pastTense: 'Disabled images for', color: Colors.Yellow },
-      ],
-      [
-        {
-          name: 'Enable image sending',
-          value: 'enable_images',
-        },
-        async (member) => {
-          return member.manageable;
-        },
-        async (member, reason) => {
-          if (!member.manageable) return false;
-          const SNOWFLAKE_MAP = await getSnowflakeMap();
-          return !!(await member.roles.remove(SNOWFLAKE_MAP.Image_Ban_Roles, reason));
-        },
-        { emoji: ':white_check_mark:', pastTense: 'Enabled images for', color: Colors.Green },
       ],
     ];
 

--- a/src/resources/dropdowns.ts
+++ b/src/resources/dropdowns.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import chokidar from 'chokidar';
+import { getDirectoryFromFileURL, getModulesInFolder } from '@utils.js';
+import modEditRoleRow from './dropdowns/dropdowns.roles.js';
+
+const DROPDOWNS = {
+  modEditRoleRow
+};
+
+// TODO: a more centralised way to reload?
+const DROPDOWNS_FOLDER = path.join(getDirectoryFromFileURL(import.meta.url), 'dropdowns');
+chokidar.watch(DROPDOWNS_FOLDER).on('change', async path => {
+  if (!path.endsWith('.js')) return;
+  (await getModulesInFolder(DROPDOWNS_FOLDER)).forEach(array =>
+    Reflect.set(DROPDOWNS, <string>array[0].split('.')[1], array[1]));
+});
+
+export default DROPDOWNS;

--- a/src/resources/dropdowns/dropdowns.roles.ts
+++ b/src/resources/dropdowns/dropdowns.roles.ts
@@ -1,0 +1,85 @@
+import { ActionRowBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, GuildMember, type Interaction, userMention, ChannelType } from 'discord.js';
+import { ResponsiveMessageSelectMenu } from '@interactionHandling/componentBuilders.js';
+import type InteractionHandler from '@interactionHandling/interactionHandler.js';
+import { getSnowflakeMap } from '@utils.js';
+import EMBEDS from '@resources/embeds.js';
+export interface RoleInfo {
+  label: string;
+  role: string;
+  enabled: boolean;
+}
+
+const SNOWFLAKE_MAP = await getSnowflakeMap();
+
+export default async function modEditRoleRow(roles: RoleInfo[], member: GuildMember) {
+  const DROPDOWN = new ActionRowBuilder<StringSelectMenuBuilder>()
+    .addComponents([
+      new ResponsiveMessageSelectMenu()
+        .setCustomId('User Roles Select Menu')
+        .setMinValues(0)
+        .setMaxValues(roles.length)
+        .addOptions(roles.map(role => {
+          return new StringSelectMenuOptionBuilder()
+            .setLabel(role.label)
+            .setValue(role.role)
+            .setDefault(role.enabled);
+        }))
+        .setResponse(async (interaction: Interaction, _interactionHandler: InteractionHandler, _command) => {
+          if (!interaction.isStringSelectMenu()) return;
+
+          let changelog = '';
+
+          roles.forEach(role => {
+            if (role.enabled && !interaction.values.includes(role.role)) removeRole(role);
+            if (!role.enabled && interaction.values.includes(role.role)) addRole(role);
+          })
+
+          function addRole(role: RoleInfo) {
+            member.roles.add(role.role, `Mod Edit Roles - ${interaction.user.id}`);
+            changelog += `+ ${role.label}\n`;
+          }
+
+          function removeRole(role: RoleInfo) {
+            member.roles.remove(role.role, `Mod Edit Roles - ${interaction.user.id}`);
+            changelog += `- ${role.label}\n`;
+          }
+
+          await interaction.update({
+            content: `Roles updated for ${userMention(member.id)}\n\`\`\`diff\n${changelog}\`\`\``,
+            components: []
+          });
+
+          const LOG_CHANNELS = SNOWFLAKE_MAP.Mod_Logs_Channels['edit_roles'] ?? SNOWFLAKE_MAP.Mod_Logs_Channels['default'];
+
+          if (!LOG_CHANNELS) return;
+
+          const LOG_EMBED = await EMBEDS.editRoleNotice(interaction.user, member.user, `\`\`\`diff\n${changelog}\`\`\``);
+
+          // fetch the log channel
+          for (const MOD_LOG_CHANNEL of LOG_CHANNELS) {
+            const LOG_CHANNEL = await interaction.client.channels.fetch(MOD_LOG_CHANNEL);
+
+            if (
+              !LOG_CHANNEL ||
+              (LOG_CHANNEL.type !== ChannelType.GuildText &&
+                LOG_CHANNEL.type !== ChannelType.GuildAnnouncement &&
+                LOG_CHANNEL.type !== ChannelType.PublicThread &&
+                LOG_CHANNEL.type !== ChannelType.PrivateThread &&
+                LOG_CHANNEL.type !== ChannelType.AnnouncementThread &&
+                LOG_CHANNEL.type !== ChannelType.DM)
+            )
+              continue;
+
+            try {
+              await LOG_CHANNEL.send({
+                embeds: [LOG_EMBED],
+                allowedMentions: { parse: [] },
+              });
+            } catch {
+              // If sending fails, it's far more important to ignore it and do the action anyway then worry and stop
+            }
+          }
+        })
+    ]);
+  return DROPDOWN;
+}

--- a/src/resources/embeds.ts
+++ b/src/resources/embeds.ts
@@ -6,6 +6,7 @@ import userReport from './embeds/embeds.userReport.js';
 import moderationLogs from './embeds/embeds.moderationLogs.js';
 import moderationNotice from './embeds/embeds.moderationNotice.js';
 import calmdownNotice from './embeds/embeds.calmdownNotice.js';
+import editRoleNotice from './embeds/embeds.editRoleNotice.js';
 import logNotice from './embeds/embeds.logNotice.js';
 
 
@@ -15,6 +16,7 @@ const EMBEDS = {
   moderationLogs,
   moderationNotice,
   calmdownNotice,
+  editRoleNotice,
   logNotice
 };
 

--- a/src/resources/embeds/embeds.editRoleNotice.ts
+++ b/src/resources/embeds/embeds.editRoleNotice.ts
@@ -1,0 +1,18 @@
+import { EmbedBuilder, User, Colors} from 'discord.js';
+
+
+export default async function editRoleNotice(staff_member: User, user: User, changelog: string) {
+
+  const EMBED = new EmbedBuilder()
+    .setColor(Colors.Fuchsia)
+    .setTitle(`✅ Edited roles for ${user.username}`)
+    .addFields([
+      { name: 'User', value: `> <@${user.id}> (\`${user.id}\`)`, inline: true },
+      { name: 'Moderator', value: `> <@${staff_member.id}>` ?? '> Error: Could not fetch moderator', inline: true },
+      { name: '\u200B', value: '\u200B' },
+
+      { name: 'Role Changes', value: changelog, inline: false },
+    ]);
+
+  return EMBED;
+}

--- a/src/resources/embeds/embeds.moderationNotice.ts
+++ b/src/resources/embeds/embeds.moderationNotice.ts
@@ -12,10 +12,6 @@ export default async function moderationNotice(log: InstanceType<typeof COLLECTI
     case 'kick': return 'kicked';
     case 'ban': return 'banned';
     case 'verify': return 'verified';
-    case 'add_mature': return 'given the mature role';
-    case 'remove_mature': return 'removed from the mature role';
-    case 'enable_images': return 'allowed to send images';
-    case 'disable_images': return 'denied from sending images';
     default: return 'warned';
     }
   })();
@@ -28,7 +24,7 @@ export default async function moderationNotice(log: InstanceType<typeof COLLECTI
 
   const RULES = await getRules();
 
-  if (log.rule && (log.action !== 'verify' && log.action !== 'add_mature' && log.action !== 'enable_images')) EMBED.addFields([{
+  if (log.rule && (log.action !== 'verify')) EMBED.addFields([{
     name: `Rule ${log.rule}`,
     value: <string>RULES[<string>log.rule[0]]?.description, // FIXME: breaks with multiple rules
     inline: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/node18-strictest-esm/tsconfig.json",
   "include": ["src/**/*.ts"],
   "compilerOptions": {
+    "sourceMap": true,
     "baseUrl": "src",
     "moduleResolution": "Node",
     "declaration": true,


### PR DESCRIPTION
Added the command and the methods to handle it, removed all old code for handing roles (except for mod based verification)

Removed any moderator limits on role edits (Minus verify as mentioned above)
We only allow members to add/remove roles which are behind the scenes for the most part, so I don't think we need to limit it, I think the harm potential is limited to none.

Avoided having /mod role save any info to the database
Same as above, just kinda unneeded, its not a mainline mod action, and we log it to a staff channel regardless. Can't see any benefits to having it in the DB as its not doing limit tracking.

Avoided sending any DMs to the user
We always edit roles after a request and I think the DM it sends is pointless.