### PR TITLE
Make notices say rule numbers not shortcodes

### DIFF
--- a/src/resources/embeds/embeds.moderationNotice.ts
+++ b/src/resources/embeds/embeds.moderationNotice.ts
@@ -25,8 +25,8 @@ export default async function moderationNotice(log: InstanceType<typeof COLLECTI
   const RULES = await getRules();
 
   if (log.rule && (log.action !== 'verify')) EMBED.addFields([{
-    name: `Rule ${log.rule}`,
-    value: <string>RULES[<string>log.rule[0]]?.description ?? <string>RULES[<string>log.rule]?.description , // FIXME: breaks with multiple rules
+    name: `Rule ${RULES[<string>log.rule]?.ruleNumber.toString()}`,
+    value: <string>RULES[<string>log.rule]?.description,
     inline: true
   }]);
 


### PR DESCRIPTION
This seems to be a regression from a while back. It's cleaner to give rule numbers to users because that way they can reference the rules, not just what the keys are in our rule object