### PR TITLE
Truncate a lot of stuff

### DIFF
--- a/src/resources/embeds/calmdownNotice.ts
+++ b/src/resources/embeds/calmdownNotice.ts
@@ -1,3 +1,4 @@
+import { truncateForFields } from '@utils.js';
 import { EmbedBuilder, Message, User } from 'discord.js';
 
 
@@ -9,7 +10,7 @@ export default async function calmdownNotice(staff_member: User, linked_message:
 
   if (reason) {
     EMBED.addFields([
-      { name: 'Reason', value: reason, inline: false },
+      { name: 'Reason', value: truncateForFields(`>>> ${reason}`), inline: false },
     ]);
   } else {
     EMBED.addFields([

--- a/src/resources/embeds/logNotice.ts
+++ b/src/resources/embeds/logNotice.ts
@@ -1,6 +1,7 @@
 import { Client, Colors, DiscordAPIError, EmbedBuilder, User, time } from 'discord.js';
 import type COLLECTIONS from '@database/collections.js';
 import { getRuleDescriptions, type ExtraActionOptions } from '@resources/commandTemplates/ActionCommand.js';
+import { truncateForFields } from '@utils.js';
 
 const durations = {
   week: 7 * 24 * 60 * 60 * 1000,
@@ -31,13 +32,6 @@ export default async function logNotice(client: Client, user: User, log: Instanc
   } catch (e) {
     if (!(e instanceof DiscordAPIError)) throw e;
   }
-
-  const reason =
-    log.reason.length <= 1020 ? log.reason : log.reason.slice(0, 1015) + '...';
-
-  const message_content =
-    (log.messageInfo?.content?.length as number) <= 1020 ? log.messageInfo?.content :
-      log.messageInfo?.content.slice(0, 1015) + '...';
 
   const title = `${extraActionOptions.emoji} ${extraActionOptions.pastTense} ${log.userState.username.replace('_', '\\_')}${log.userState.discriminator === '0' ? ''
     : '#' + log.userState.discriminator}`;
@@ -77,7 +71,7 @@ export default async function logNotice(client: Client, user: User, log: Instanc
 
   EMBED.addFields([
     { name: '\u200B', value: '\u200B' },
-    { name: 'Reason', value: `>>> ${reason}` },
+    { name: 'Reason', value: truncateForFields(`>>> ${log.reason}`) },
   ]);
 
   if (log.privateNotes) {
@@ -97,7 +91,7 @@ export default async function logNotice(client: Client, user: User, log: Instanc
     if (log.messageInfo.content) {
       EMBED.addFields([{
         name: 'Infracting Message Content',
-        value: `>>> ${message_content}`,
+        value: truncateForFields(`>>> ${log.messageInfo.content}`),
       }]);
     }
 

--- a/src/resources/embeds/messageReport.ts
+++ b/src/resources/embeds/messageReport.ts
@@ -1,5 +1,6 @@
 import { Guild, Message, EmbedBuilder, type Snowflake, User } from 'discord.js';
 import COLLECTIONS from '@database/collections.js';
+import { truncateForFields } from '@utils.js';
 
 function pushReportsCount(array: string[], length: number, prevTimeLength: number, time: string) {
   if (length && length > prevTimeLength)
@@ -28,7 +29,7 @@ export default async function messageReport(reporter: User, reason: string, mess
     .setAuthor({ name: 'Reported User', iconURL: message.author.displayAvatarURL(), url: `https://discord.com/users/${message.author.id}` })
     .setDescription(`> ${message.author.toString()} (\`${message.author.username}\`)`)
     .addFields([
-      { name: 'Reason', value: reason, inline: true },
+      { name: 'Reason', value: truncateForFields(`>>> ${reason}`), inline: true },
       { name: 'This user has been reported', value: await reportsCountSummary(message.author.id), inline: true },
       { name: '\u200b', value: '\u200b' },
       {
@@ -45,7 +46,7 @@ export default async function messageReport(reporter: User, reason: string, mess
   if (message.content) EMBED.addFields([
     {
       name: 'Reported Message Content',
-      value: message.content,
+      value: truncateForFields(`>>> ${message.content}`),
       inline: false
     }
   ]);

--- a/src/resources/embeds/moderationLogs.ts
+++ b/src/resources/embeds/moderationLogs.ts
@@ -1,8 +1,9 @@
 import { EmbedBuilder, User } from 'discord.js';
 import COLLECTIONS from '@database/collections.js';
-import { getCustomisations, getRules } from '@utils.js';
+import { getCustomisations, getRules, truncateForFields } from '@utils.js';
 
 // TODO: give more info and polish layout
+
 
 export default async function moderationLogs(user: User, page = 1) {
   const LPP = (await getCustomisations()).Moderation_Logs_Per_Page;
@@ -23,19 +24,19 @@ export default async function moderationLogs(user: User, page = 1) {
       return [
         {
           name: ruleText,
-          value: log.reason,
+          value: truncateForFields(log.reason),
           inline: true
         },
         {
           name: 'Private Notes',
-          value: log.privateNotes ?? 'None given',
+          value: truncateForFields(log.privateNotes ?? 'None given'),
           inline: true
         },
         {
           name: `<t:${Math.floor(log.timestamp / 1000)}:R>`,
           value: log.action,
           inline: true
-        }
+        },
       ]
     }).flat());
   return EMBED;

--- a/src/resources/embeds/moderationNotice.ts
+++ b/src/resources/embeds/moderationNotice.ts
@@ -1,6 +1,6 @@
 import { Colors, EmbedBuilder } from 'discord.js';
 import type COLLECTIONS from '@database/collections.js';
-import { getRules } from '@utils.js';
+import { getRules, truncateForFields } from '@utils.js';
 
 export default async function moderationNotice(log: InstanceType<typeof COLLECTIONS.ModerationLog>) {
   // TODO: more centralized actions definition? possibly add them to templates.actionCommand.ts
@@ -32,7 +32,7 @@ export default async function moderationNotice(log: InstanceType<typeof COLLECTI
 
   if (log.messageInfo?.content) EMBED.addFields([{
     name: 'Infracting Message Content',
-    value: log.messageInfo.content,
+    value: truncateForFields(`>>> ${log.messageInfo.content}`),
     inline: false
   }]);
 

--- a/src/resources/embeds/purgeLogs.ts
+++ b/src/resources/embeds/purgeLogs.ts
@@ -1,3 +1,4 @@
+import { truncateForFields } from '@utils.js';
 import { Client, Colors, DiscordAPIError, EmbedBuilder, User } from 'discord.js';
 
 export default async function logNotice(client: Client, moderator: User, users: User[], reason: string, amount: number, privateNotes?: string, attachmentURL?: string) {
@@ -27,14 +28,14 @@ export default async function logNotice(client: Client, moderator: User, users: 
   }
 
   EMBED.addFields([
-    { name: 'Affected Users', value: `>>> ${users.map(u => `<@${u.id}> (\`${u.username}\`)`).join('\n')}`, inline: false },
-    { name: 'Reason', value: `>>> ${reason}`, inline: false }
+    { name: 'Affected Users', value: truncateForFields(`>>> ${users.map(u => `<@${u.id}> (\`${u.username}\`)`).join('\n')}`), inline: false },
+    { name: 'Reason', value: truncateForFields(`>>> ${reason}`), inline: false }
   ]);
 
   if (privateNotes) {
     EMBED.addFields([{
       name: 'Private Notes',
-      value: `>>> ${privateNotes}`,
+      value: truncateForFields(`>>> ${privateNotes}`),
       inline: false,
     }]);
   }

--- a/src/resources/embeds/userReport.ts
+++ b/src/resources/embeds/userReport.ts
@@ -1,5 +1,6 @@
 import { EmbedBuilder, type Snowflake, User, VoiceState } from 'discord.js';
 import COLLECTIONS from '@database/collections.js';
+import { truncateForFields } from '@utils.js';
 
 function pushReportsCount(array: string[], length: number, prevTimeLength: number, time: string) {
   if (length && length > prevTimeLength)
@@ -28,7 +29,7 @@ export default async function messageReport(reporter: User, reason: string, user
     .setAuthor({ name: 'Reported User', iconURL: user.displayAvatarURL(), url: `https://discord.com/users/${user.id}` })
     .setDescription(`> ${user.toString()} (\`${user.username}\`)`)
     .addFields([
-      { name: 'Reason', value: reason, inline: true },
+      { name: 'Reason', value: truncateForFields(`>>> ${reason}`), inline: true },
       { name: 'This user has been reported', value: await reportsCountSummary(user.id), inline: true },
       { name: '\u200b', value: '\u200b' },
       { name: 'Reported By', value: `${reporter.toString()} (\`${reporter.username}\`)`, inline: true },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,3 +93,8 @@ export function watchAndReloadCommands(interactionHandler: InteractionHandler) {
 export function t(strings: TemplateStringsArray, ...interpolations: any[]) {
   return hAddTimestamp(strings, interpolations);
 }
+
+export function truncateForFields(s: string) {
+    return s.length <= 1020 ? s :
+    s.slice(0, 1015) + '...';
+}


### PR DESCRIPTION
Turns out we didn't truncate anything in message reports.
Because of this, I added a `truncateForFields` util function and truncated pretty much everything with even a small chance of being too large :3