### PR TITLE
Fix empty role diff

### DIFF
--- a/src/resources/dropdowns/roles.ts
+++ b/src/resources/dropdowns/roles.ts
@@ -47,6 +47,15 @@ export default async function modEditRoleRow(roles: RoleInfo[], member: GuildMem
 
           await member.roles.set([...memberRoles], `Mod Edit Roles - ${interaction.user.id}`);
 
+          if (changelog === '') {
+            await interaction.update({
+              content: `Role update confirmed for ${userMention(member.id)} with no roles modified.`,
+              components: []
+            });
+
+            return;
+          }
+
           await interaction.update({
             content: `Roles updated for ${userMention(member.id)}\n\`\`\`diff\n${changelog}\`\`\``,
             components: []


### PR DESCRIPTION
when running `/mod roles`, an empty diff will be produced if the user submits no changes (as is possible on mobile) or if the changes were already made and the updated selection already matches the user's roles. this commit prevents this from showing an empty diff to the user and confirms to them that their changes were made correctly and also skips sending a blank diff to the log channel