### PR TITLE
fix mod logs not showing pages

### DIFF
--- a/src/resources/embeds/moderationLogs.ts
+++ b/src/resources/embeds/moderationLogs.ts
@@ -20,7 +20,7 @@ export default async function moderationLogs(user: User, showHidden = false, pag
   const LOGS = await COLLECTIONS.UserLog.getUserAndConnectedLogs(user.id);
   const entries = LOGS.flatMap((log) => log.moderationLogs.map((entry) => ({ userID: log.userID, ...entry }))).sort((a, b) => a.timestamp - b.timestamp);
 
-  const PAGES = Math.ceil(LOGS.length / LPP);
+  const PAGES = Math.ceil(entries.length / LPP);
   const STARTING_INDEX = (page - 1) * LPP;
   const RULES = await getRules();
 


### PR DESCRIPTION
a previous change allowing mod logs to show alt accounts' infractions inadvertently broke pages for users with more than 6 warnings due to `LOGS` becoming a `UserLog[]` instead of just a `UserLog`

this change fixes that

tests:
- `/mod logs` now shows pages for users with sufficient mod actions and you can click through the pages as normal