### PR TITLE
fix certain staff commands denying permission in staff server

### DIFF
--- a/configs/snowflakeMapType.d.ts
+++ b/configs/snowflakeMapType.d.ts
@@ -6,6 +6,11 @@ export default interface snowflakeMap {
   Discord_Guilds?: string[];
 
   /**
+   * Grants access to staff commands that are enabled in the staff server
+   */
+  Staff_Server_Staff_Roles: string[];
+
+  /**
    * Stops staff from punishing other staff
    */
   Staff_Roles: string[];

--- a/src/commands/mod/logs.ts
+++ b/src/commands/mod/logs.ts
@@ -23,13 +23,14 @@ export default new ResponsiveSlashCommandSubcommandBuilder()
     await interaction.deferReply({ ephemeral: true });
 
     const SNOWFLAKE_MAP = await getSnowflakeMap();
+    const ANY_SERVER_STAFF_ROLES = [...SNOWFLAKE_MAP.Staff_Roles, ...SNOWFLAKE_MAP.Staff_Server_Staff_Roles];
 
     const IS_STAFF_MEMBER =
       interaction.member?.roles instanceof GuildMemberRoleManager ?
-        interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Staff_Roles) :
+        interaction.member.roles.cache.hasAny(...ANY_SERVER_STAFF_ROLES) :
 
         interaction.member?.roles instanceof Array ?
-          SNOWFLAKE_MAP.Staff_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          ANY_SERVER_STAFF_ROLES.some(r => (<string[]>interaction.member?.roles).includes(r)) :
           undefined;
 
     if (!IS_STAFF_MEMBER) {

--- a/src/commands/mod/toggle.ts
+++ b/src/commands/mod/toggle.ts
@@ -25,13 +25,14 @@ export default new ResponsiveSlashCommandSubcommandBuilder()
     await interaction.deferReply({ ephemeral: true });
 
     const SNOWFLAKE_MAP = await getSnowflakeMap();
+    const ANY_SERVER_STAFF_ROLES = [...SNOWFLAKE_MAP.Staff_Roles, ...SNOWFLAKE_MAP.Staff_Server_Staff_Roles];
 
     const IS_STAFF_MEMBER =
       interaction.member?.roles instanceof GuildMemberRoleManager ?
-        interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Staff_Roles) :
+        interaction.member.roles.cache.hasAny(...ANY_SERVER_STAFF_ROLES) :
 
         interaction.member?.roles instanceof Array ?
-          SNOWFLAKE_MAP.Staff_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          ANY_SERVER_STAFF_ROLES.some(r => (<string[]>interaction.member?.roles).includes(r)) :
           undefined;
 
     if (!IS_STAFF_MEMBER) {

--- a/src/resources/commandTemplates/ActionCommand.ts
+++ b/src/resources/commandTemplates/ActionCommand.ts
@@ -4,7 +4,8 @@ import {
   GuildMember,
   Message,
   User,
-  Colors
+  Colors,
+  GuildMemberRoleManager
 } from 'discord.js';
 import {
   SlashCommandBooleanOption,
@@ -399,6 +400,19 @@ export default class ActionCommand extends ResponsiveSlashCommandSubcommandBuild
     if (!interaction.deferred && !interaction.replied) await interaction.deferReply({ ephemeral: true });
 
     const SNOWFLAKE_MAP = await getSnowflakeMap();
+
+    const IS_STAFF_MEMBER =
+      interaction.member?.roles instanceof GuildMemberRoleManager ?
+        interaction.member.roles.cache.hasAny(...SNOWFLAKE_MAP.Staff_Roles) :
+
+        interaction.member?.roles instanceof Array ?
+          SNOWFLAKE_MAP.Staff_Roles.some(r => (<string[]>interaction.member?.roles).includes(r)) :
+          undefined;
+
+    if (!IS_STAFF_MEMBER) {
+      await interaction.followUp({ content: 'You do not have permission to use this command.', ephemeral: true });
+      return;
+    }
 
     // TODO: https://discord.com/channels/@me/960632564912115763/981297877131333642
     // get basic options


### PR DESCRIPTION
after the previous fix, /mod logs and /mod toggle are no longer allowed in the staff server due to the roles not existing there

certain commands such as /calmdown and /mod user should still not be allowed in the staff server, so I've added an extra field to the configuration for staff roles in the staff server that enables /mod logs and /mod toggle but nothing else

tested:
- users without either role cannot use any of the commands anywhere
- users with the staff server role can use /mod logs and /mod toggle but not any of the other commands
- users with the main server role can use all of the commands including /mod user, /mod logs, and /mod toggle