### PR TITLE
fix(logs): avoid crash on no alt switch logs

### DIFF
--- a/src/database/collections/userLogs.ts
+++ b/src/database/collections/userLogs.ts
@@ -20,6 +20,7 @@ let cachedAltSwitchLogs: Map<string, string[]> | undefined;
 let cachedAltLogsAt = 0;
 
 async function fetchAltSwitchLogs() {
+  if (!config.Alt_Account_Sheet_URL) return new Map<string, string[]>();
   if (Date.now() - cachedAltLogsAt < 5 * 60 * 1000 && cachedAltSwitchLogs) return cachedAltSwitchLogs;
   const request = await fetch(config.Alt_Account_Sheet_URL);
   const text = request.ok ? await request.text() : '';


### PR DESCRIPTION
GA, who use Badeline, don't have an alt switch spreadsheet - we shouldn't fail out of reading logs if it doesn't exist