### PR TITLE
add self-timeout command

### DIFF
--- a/src/commands/selfTimeout.ts
+++ b/src/commands/selfTimeout.ts
@@ -1,0 +1,45 @@
+import { ResponsiveSlashCommandBuilder } from '@interactionHandling/commandBuilders.js';
+import { SlashCommandBooleanOption, SlashCommandIntegerOption } from '@discordjs/builders';
+import BUTTONS from '@resources/buttons.js';
+
+export default new ResponsiveSlashCommandBuilder()
+  .setName('self-timeout')
+  .setDescription('Give yourself a timeout between 1 and 24 hours (you will not be able to remove this)')
+  .setDMPermission(false)
+  .addIntegerOption(new SlashCommandIntegerOption()
+    .setName('hours')
+    .setDescription('the number of hours to time you out for')
+    .setRequired(true)
+    .setMinValue(1)
+    .setMaxValue(24)
+  )
+  .addBooleanOption(new SlashCommandBooleanOption()
+    .setName('public')
+    .setDescription('if true, send a public notification that this command was used')
+  )
+  .setResponse(async (interaction, _interactionHandler, _command) => {
+    if (!interaction.isChatInputCommand()) return;
+    if (!interaction.guild) return;
+    BUTTONS.selfTimeoutConfirm.components.forEach(i => _interactionHandler.addComponent(i));
+
+    const member = await interaction.guild.members.fetch(interaction.user.id);
+    if (!member) return;
+
+    if (!member.manageable) {
+      await interaction.reply({
+        content: 'You cannot be timed out by the bot (your highest role is higher than the bot\'s or you are an admin).',
+        ephemeral: true,
+      });
+
+      return;
+    }
+
+    const hours = interaction.options.getInteger('hours', true);
+    const showPublicly = interaction.options.getBoolean('public', false) ?? false;
+
+    await interaction.reply({
+      content: `Confirm that you wish to be timed out for ${hours} hour${hours === 1 ? '' : 's'}? Staff will not undo this timeout. A public notice ${showPublicly ? '**will** be sent in this channel' : 'will **not** be sent'}.`,
+      components: [BUTTONS.selfTimeoutConfirm],
+      ephemeral: true,
+    });
+  });

--- a/src/resources/buttons.ts
+++ b/src/resources/buttons.ts
@@ -4,10 +4,12 @@ import { getDirectoryFromFileURL, getModulesInFolder } from '@utils.js';
 import modLogActionRow from './buttons/moderationLog.js';
 import reportActionRow from './buttons/report.js'
 import toggleLog from './buttons/toggleLog.js'
+import selfTimeoutConfirm from './buttons/selfTimeoutConfirm.js';
 
 const BUTTONS = {
   modLogActionRow,
   reportActionRow,
+  selfTimeoutConfirm,
   toggleLog
 };
 

--- a/src/resources/buttons/selfTimeoutConfirm.ts
+++ b/src/resources/buttons/selfTimeoutConfirm.ts
@@ -1,0 +1,57 @@
+import { ResponsiveMessageButton } from '@interactionHandling/componentBuilders.js';
+import { ActionRowBuilder, ButtonStyle, type Interaction, Message } from 'discord.js';
+
+function getConfiguration(message: Message) {
+  const content = message.content;
+  const hours = parseInt(content.match(/(\d+) hour/)?.[0] ?? '0');
+  const showPublicly = !!content.includes('**will**');
+  return { hours, showPublicly };
+}
+
+export default new ActionRowBuilder<ResponsiveMessageButton>()
+  .addComponents([
+    new ResponsiveMessageButton()
+      .setCustomId('Self Timeout Confirm')
+      .setLabel('Confirm Self-Timeout')
+      .setStyle(ButtonStyle.Danger)
+      .setResponse(async (interaction: Interaction) => {
+        if (!interaction.isButton()) return;
+
+        const { hours, showPublicly } = getConfiguration(interaction.message);
+
+        await interaction.deferUpdate();
+
+        const member = await interaction.guild?.members.fetch(interaction.user.id); // we already checked being in a guild when handling the slash command
+
+        if (!member) {
+          await interaction.editReply({
+            content: 'Could not fetch your member object (this error should not occur).',
+            components: [],
+          });
+
+          return;
+        }
+
+        if (!member.manageable) {
+          // this shouldn't be possible, but just in case the member becomes an admin, we don't want to throw an error
+          await interaction.editReply({
+            content: 'You cannot be timed out; this is unexpected unless your roles changed since you ran the command.',
+            components: [],
+          });
+
+          return;
+        }
+
+        await member.timeout(hours * 60 * 60 * 1000, 'self-requested using /self-timeout');
+
+        if (showPublicly) {
+          await interaction.deleteReply().catch(() => null); // catching just in case they dismiss the message
+          await interaction.channel?.send(`${interaction.user} has requested a timeout for ${hours} hour${hours === 1 ? '' : 's'} with \`/self-timeout\`.`);
+        } else {
+          await interaction.editReply({
+            content: `You have been timed out for ${hours} hour${hours === 1 ? '' : 's'}.`,
+            components: [],
+          });
+        }
+      })
+  ]);


### PR DESCRIPTION
tested:

- timeout for 1 hour, public unset/false: confirms "timeout for 1 hour" and says "you have been timed out for 1 hour" privately
- timeout for X hours, public unset/false: confirms "timeout for X hour**s**" and says "you have been timed out for X hour**s**" privately
- timeout for 1 hour, public true: confirms "timeout for 1 hour" and says "user requested a timeout for 1 hour" publicly
- timeout for X hours, public true: confirms "timeout for X hour**s**" and says "user requested a timeout for X hour**s**" publicly

pluralization works correctly. the reason it's "requested a timeout for X hours" instead of "requested a X hour timeout" because otherwise it would be awkward without checking "a" vs. "an" (e.g. "a 4 hour" but "an 8 hour") and I don't feel like doing that

if we want the wording to be "a[n] X hour timeout" let me know and I'll make it work (X can only be 1 through 24 anyway)