### PR TITLE
add 'send publicly' button to mod logs in allowed channels

### DIFF
--- a/configs/snowflakeMapType.d.ts
+++ b/configs/snowflakeMapType.d.ts
@@ -54,6 +54,12 @@ export default interface snowflakeMap {
   Mod_Logs_Channels: Record<string, string[]>;
 
   /**
+   * Channels where /mod logs should show a "send publicly" button (will work in
+   * all child channels)
+   */
+  Allow_Public_Mod_Logs_Channels: string[];
+
+  /**
    * A list of roles that members verified with /mod user verify should be given
    * Often this will be the same role that you use in your regular verification
    * system, however you may want to add multiple roles (i.e. to track who was

--- a/src/resources/buttons.ts
+++ b/src/resources/buttons.ts
@@ -5,12 +5,14 @@ import modLogActionRow from './buttons/moderationLog.js';
 import reportActionRow from './buttons/report.js'
 import toggleLog from './buttons/toggleLog.js'
 import selfTimeoutConfirm from './buttons/selfTimeoutConfirm.js';
+import sendPubliclyButton from './buttons/sendPubliclyButton.js';
 
 const BUTTONS = {
   modLogActionRow,
   reportActionRow,
   selfTimeoutConfirm,
-  toggleLog
+  toggleLog,
+  sendPubliclyButton,
 };
 
 // TODO: a more centralised way to reload?

--- a/src/resources/buttons/moderationLog.ts
+++ b/src/resources/buttons/moderationLog.ts
@@ -14,7 +14,7 @@ function get_page_info(embed: Embed) {
   };
 }
 
-async function get_log_user(client: Client, embed: Embed) {
+export async function get_log_user(client: Client, embed: Embed) {
   const regex = /> <@([0-9]+)>/gm;
   const match = regex.exec(embed.description as string);
   if (!match || !match[1]) return undefined;
@@ -22,7 +22,7 @@ async function get_log_user(client: Client, embed: Embed) {
   return await client.users.fetch(match[1]);
 }
 
-function get_showing_hidden(embed: Embed) {
+export function get_showing_hidden(embed: Embed) {
   const regex = /Showing Hidden: (true|false)/gm;
   const match = regex.exec(embed.footer?.text as string);
   if (!match) return false;

--- a/src/resources/buttons/sendPubliclyButton.ts
+++ b/src/resources/buttons/sendPubliclyButton.ts
@@ -1,0 +1,39 @@
+import { ResponsiveMessageButton } from '@interactionHandling/componentBuilders.js';
+import type InteractionHandler from '@interactionHandling/interactionHandler.js';
+import { moderationAllLogs } from '@resources/embeds/moderationLogs.js';
+import { ActionRowBuilder, ButtonStyle, type Interaction } from 'discord.js';
+import { get_log_user, get_showing_hidden } from './moderationLog.js';
+
+export default new ActionRowBuilder<ResponsiveMessageButton>()
+  .addComponents([
+    new ResponsiveMessageButton()
+      .setCustomId('Send Publicly')
+      .setLabel('Send Publicly')
+      .setEmoji({ name: '📢' })
+      .setStyle(ButtonStyle.Danger)
+      .setResponse(async (interaction: Interaction, _interactionHandler: InteractionHandler, _command) => {
+        if (!interaction.isButton()) return;
+
+        await interaction.update({
+          content: 'Sending all logs publicly; you may dismiss this message.',
+          embeds: [],
+          components: [],
+        });
+
+        const this_embed = interaction.message.embeds[0];
+        const user = this_embed && await get_log_user(interaction.client, this_embed);
+
+        if (!user) {
+          await interaction.followUp({
+            content: 'Could not find the user; tell the devs',
+            ephemeral: true,
+          });
+          return;
+        }
+
+        for (const PAGE of await moderationAllLogs(user, get_showing_hidden(this_embed), interaction.user))
+          await interaction.channel?.send({ embeds: [PAGE] });
+
+        await interaction.editReply('Successfully sent logs publicly.');
+      }),
+  ]);


### PR DESCRIPTION
- when in explicitly allowed channels (those in `SNOWFLAKE_MAP.Allow_Public_Mod_Logs_Channels` and their descendents), `/mod logs` shows a `Send Publicly` button
- pressing the button will dump ALL of the user's mod logs (obeying the `showHidden` setting from the original command) into the channel publicly (since pagination breaks if multiple users are trying to click at the same time)

tested:
- shows button in allowed channels
- does not show button in any channels not explicitly allowed
- pressing the button sends all logs publicly (without repeating the header)
- the button obeys the original command's showing hidden value

additional:
- now shows `[alt]` as the "index" for logs imported from linked alt accounts to prevent confusion when trying to target infractions with `/mod toggle`
- now shows the maximum number of items per page regardless of hidden items in the middle (previously, a page that would have a hidden item instead shows one fewer item than it should)