### PR TITLE
implement ability to purge messages on kicking

### DIFF
--- a/src/database/collections/userLogs/moderationLogs.ts
+++ b/src/database/collections/userLogs/moderationLogs.ts
@@ -69,7 +69,7 @@ export default class ModerationLog {
 
     this.rule = rule;
     if (privateNotes) this.privateNotes = privateNotes;
-    if ((action === 'timeout' || action === 'ban') && duration) this.duration = duration;
+    if ((action === 'timeout' || action === 'ban' || action === 'kick') && duration) this.duration = duration;
     if (keepMessage) this.keepMessage = keepMessage;
     if (message) this.messageInfo = getMessageInfo(message);
   }

--- a/src/resources/embeds/logNotice.ts
+++ b/src/resources/embeds/logNotice.ts
@@ -66,7 +66,7 @@ export default async function logNotice(client: Client, user: User, log: Instanc
       }]);
     }
 
-    if (log.action === 'ban') {
+    if (log.action === 'ban' || log.action === 'kick') {
       EMBED.addFields([{
         name: 'Deleted Messages For',
         value: `> ${duration}`,


### PR DESCRIPTION
tested
- banning a user with or without a purge duration is not affected by this change at all
- kicking a user without a duration is not affected by this change at all
- kicking a user with a duration now bans then unbans them to purge messages for that duration but still logs it and notifies the user as a kick

intentionally not tested
- handling if the unban fails. impossible to realistically replicate this without just injecting an error which isn't really testing the actual handler itself anymore, and it's pretty obvious that the `.catch` on the unban will trigger if the unbanning fails and give the necessary feedback to the executor (there are niche situations in which this notification will perhaps not be visible due to discord's weird handling of calling commands while you are scrolled up, but this situation should be so implausible that I am comfortable with this risk)